### PR TITLE
Correct name of original author

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Morphological analyzer (POS tagger + inflection engine)
 for Russian and Ukrainian languages.
 
 ## Links
-Repo is fork of [Korobov Mykhail](https://github.com/kmike/pymorphy2) and follows all rules of MIT license.
+Repo is fork of [Mikhail Korobov](https://github.com/kmike/pymorphy2) and follows all rules of MIT license.


### PR DESCRIPTION
The order of first and last name of the original author is wrong in README, so this PR fixes it.