### PR TITLE
Restore backward compatibility of the dictionary format

### DIFF
--- a/pymorphy3/dawg.py
+++ b/pymorphy3/dawg.py
@@ -43,7 +43,7 @@ class PredictionSuffixesDAWG(WordsDawg):
     # We are storing 3 unsigned short ints as values:
     # count, the paradigm ID and the form index (inside paradigm).
     # Byte order is big-endian (this makes word forms properly sorted).
-    DATA_FORMAT = str(">IHH")
+    DATA_FORMAT = str(">HHH")
 
 
 class ConditionalProbDistDAWG(IntCompletionDAWG):


### PR DESCRIPTION
Hi, after some tinkering with `pymorphy2-dicts` I've figured how to support recent versions of the Ukrainian dictionary ([ВЕСУМ](https://github.com/brown-uk/dict_uk), I'm using [v6.1.0](https://github.com/brown-uk/dict_uk/releases/tag/v6.1.0)) without breaking backward compatibility of the dictionary format:
- `PredictionSuffixesDAWG` originally [required](https://github.com/no-plagiarism/pymorphy3/blob/1d9c310c/pymorphy3/dawg.py#L43) each of the numbers stored in it: count, paradigm ID, form index – to be unsigned short, i.e. to fall into the range 0...65535.
- However, the counts calculated [here](https://github.com/no-plagiarism/pymorphy3/blob/1d9c310c/pymorphy3/opencorpora_dict/compile.py#L357) sometimes violate the range. Please note: these are suffix counts in paradigms, not suffix sizes, contrary to what is stated [here](https://github.com/pymorphy2/pymorphy2/issues/160#issuecomment-1333281298).
- In particular, suffixes of the Ukrainian adjectival paradigm (*-ий*, *-ого*, *-ому*, *-им*, *-ім*, etc.) have frequency 76035. As of ВЕСУМ v6.1.0, no other suffix counts violate the range of unsigned short. Upon subsequent updates of the dictionary, I wouldn't expect any significant change, as nominal and verbal paradigms are more diverse, and none of them are likely to grow above 65535 lemmas any time soon, given that ВЕСУМ contains several hundred thousand lemmas in total.
- My proposal is to introduce a parameter `max_ending_freq`, defaulting to 65535, and cut off all suffix counts above `max_ending_freq`, so that they would fit into unsigned short. Although the proposed change may theoretically affect [candidate ordering](https://pymorphy2.readthedocs.io/en/stable/internals/prediction.html#id9) for out-of-vocabulary words, it also ensures backward compatibility of the dictionary format and slightly reduces memory usage.

On a side note, a couple of changes in the [fork](https://github.com/no-plagiarism/LT3OpenCorpora) of LT2OpenCorpora might be required to process a recent version of ВЕСУМ:
- The [PoS mapping](https://github.com/no-plagiarism/LT3OpenCorpora/blob/0d29e1d2/lt3opencorpora/mapping.csv) is out of date: `excl` has [changed](https://github.com/brown-uk/dict_uk/issues/89) to `intj`, non-inflected words are now [marked](https://github.com/brown-uk/dict_uk/commit/be7fb075) `noninfl` instead of `nv`, a separate tag `onomat` was [introduced](https://github.com/brown-uk/dict_uk/commit/2dcf3af3) for onomatopoetic words (звуконаслідування), etc.
- The [`.bz2` check](https://github.com/no-plagiarism/LT3OpenCorpora/blob/0d29e1d2/bin/lt_convert.py#L27) doesn't work for me, when I'm supplying a [link](https://github.com/brown-uk/dict_uk/releases/download/v6.1.0/dict_corp_vis.txt.bz2) to the bzipped dictionary file. I've fixed this by adding `or url.endswith(".bz2")` to the condition.

While these remarks are not directly related to the dictionary format, I'm sharing them here to keep you informed. Please let me know if instead I should open PRs in LT3OpenCorpora repo.