### PR TITLE
Change docopt to updated fork

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ py_version = sys.version_info[:2]
 
 install_requires = [
     'dawg-python >= 0.7.1',
-    'docopt >= 0.6',
+    'docopt-ng >= 0.6',
     'pymorphy3-dicts-ru'
 ]
 if py_version < (3, 0):


### PR DESCRIPTION
The current dependency docopt has been abandoned for several years. This PR changes it to an updated fork. I tested the CLI functions, they still seem to work. 

I especially need this because the original docopt has not published a wheel on pypi, which makes using pymorphy3 on the web using pyodide currently impossible.