### PR TITLE
Switch CLI dependency from docopt to Click and make it optional

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -1,23 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-Pymorphy2 benchmark utility.
-
-Usage:
-    bench.py run [--dict=<DICT_PATH>] [--repeats=<NUM>] [--verbose]
-    bench.py -h | --help
-    bench.py --version
-
-Options:
-    -d --dict <DICT_PATH>   Use dictionary from <DICT_PATH>
-    -r --repeats <NUM>      Number of times to run each benchmarks [default: 5]
-    -v --verbose            Be more verbose
-
-"""
 import logging
 import sys
 import os
-from docopt import docopt
+import click
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -27,21 +13,26 @@ from benchmarks import speed
 logger = logging.getLogger('pymorphy3.bench')
 logger.addHandler(logging.StreamHandler())
 
-
+@click.group()
+@click.help_option('-h', '--help')
+@click.version_option(version=pymorphy3.__version__, message='%(version)s')
 def main():
-    """ CLI interface dispatcher """
-    args = docopt(__doc__, version=pymorphy3.__version__)
+    """ Pymorphy2 benchmark utility. """
 
-    if args['--verbose']:
+@main.command(context_settings={'show_default': True})
+@click.option('-d', '--dict', 'DICT_PATH', metavar='DICT_PATH', help='Use dictionary from <DICT_PATH>')
+@click.option('-r', '--repeats', default=5, help='Number of times to run each benchmarks')
+@click.option('-v', '--verbose', is_flag=True, help='Be more verbose')
+def run(DICT_PATH, repeats, verbose):
+    if verbose:
         logger.setLevel(logging.DEBUG)
     else:
         logger.setLevel(logging.INFO)
 
-    if args['run']:
-        speed.bench_all(
-            dict_path=args['--dict'],
-            repeats=int(args['--repeats'])
-        )
+    speed.bench_all(
+        dict_path=DICT_PATH,
+        repeats=int(repeats)
+    )
 
     return 0
 

--- a/pymorphy3/cli.py
+++ b/pymorphy3/cli.py
@@ -8,7 +8,11 @@ import time
 import codecs
 import operator
 
-import click
+try:
+    import click
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError('''pymorphy2's command line tools require Click which is not currently installed. Try installing Click via "pip install click".''') from e
+
 import pymorphy3
 from pymorphy3.cache import lru_cache, memoized_with_single_argument
 from pymorphy3.utils import get_mem_usage

--- a/pymorphy3/cli.py
+++ b/pymorphy3/cli.py
@@ -8,6 +8,7 @@ import time
 import codecs
 import operator
 
+import click
 import pymorphy3
 from pymorphy3.cache import lru_cache, memoized_with_single_argument
 from pymorphy3.utils import get_mem_usage
@@ -15,12 +16,6 @@ from pymorphy3.tokenizers import simple_word_tokenize
 
 PY2 = sys.version_info[0] == 2
 
-# Hacks are here to make docstring compatible with both
-# docopt and sphinx.ext.autodoc.
-head = """
-
-Pymorphy2 is a morphological analyzer / inflection engine for Russian language.
-"""
 __doc__ = """
 Usage::
 
@@ -48,7 +43,6 @@ Options::
     -h --help           Show this help
 
 """
-DOC = head + __doc__.replace('::\n', ':')
 
 # TODO:
 #   -i --inline         Don't start each output result with a new line
@@ -60,53 +54,72 @@ logger = logging.getLogger('pymorphy3')
 
 
 # ============================== Entry point ============================
+@click.group()
+@click.help_option('-h', '--help')
+@click.version_option(version=pymorphy3.__version__, message='%(version)s')
 def main(argv=None):
     """
-    Pymorphy CLI interface dispatcher.
+    Pymorphy2 is a morphological analyzer / inflection engine for Russian language.
     """
 
-    from docopt import docopt
-    args = docopt(DOC, argv, version=pymorphy3.__version__)
+@main.command(name='parse', context_settings={'show_default': True})
+@click.option('--dict', 'path', help='Dictionary folder path')
+@click.option('--lang', default='ru', help='Language to use. Allowed values: ru, uk')
+@click.option('-l', '--lemmatize', is_flag=True, help='Include normal forms (lemmas)')
+@click.option('-s', '--score', is_flag=True, help='Include non-contextual P(tag|word) scores')
+@click.option('-t', '--tag', is_flag=True, help='Include tags')
+@click.option('--tokenized', is_flag=True, help='Assume that input text is already tokenized: one token per line.')
+@click.option('-c', '--cache', default=20000, help="Cache size, in entries. Set it to 0 to disable cache; use 'unlim' value for unlimited cache size")
+@click.option('--thresh', default=0.0, help='Drop all results with estimated P(tag|word) less than a threshold')
+@click.argument('input_', metavar='INPUT', required=False)
+def cli_parse(path, lang, score, lemmatize, tag, tokenized, cache, thresh, input_):
+    morph = pymorphy3.MorphAnalyzer(path=path, lang=lang)
+    in_file = _open_for_read(input_)
 
-    path = args['--dict']
-    lang = args['--lang']
+    if not any([score, lemmatize, tag]):
+        score, lemmatize, tag = True, True, True
 
-    if args['parse']:
-        morph = pymorphy3.MorphAnalyzer(path=path, lang=lang)
-        in_file = _open_for_read(args['<input>'])
+    if PY2:
+        out_file = codecs.getwriter('utf8')(sys.stdout)
+    else:
+        out_file = sys.stdout
 
-        if any([args['--score'], args['--lemmatize'], args['--tag']]):
-            score, lemmatize, tag = args['--score'], args['--lemmatize'], args['--tag']
-        else:
-            score, lemmatize, tag = True, True, True
+    return parse(
+        morph=morph,
+        in_file=in_file,
+        out_file=out_file,
+        tokenize=not tokenized,
+        score=score,
+        normal_form=lemmatize,
+        tag=tag,
+        newlines=True,  # not args['--inline'],
+        cache_size=cache,
+        thresh=thresh,
+    )
+@main.group(name='dict')
+def cli_dict():
+    pass
 
-        if PY2:
-            out_file = codecs.getwriter('utf8')(sys.stdout)
-        else:
-            out_file = sys.stdout
+@cli_dict.command(name='mem_usage', context_settings={'show_default': True})
+@click.option('--lang', default='ru', help='Language to use. Allowed values: ru, uk')
+@click.option('--dict', 'path', help='Dictionary folder path')
+@click.option('-v', '--verbose', is_flag=True, help='Be more verbose')
+def cli_dict_mem_usage(lang, path, verbose):
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.debug([lang, path, verbose])
 
-        return parse(
-            morph=morph,
-            in_file=in_file,
-            out_file=out_file,
-            tokenize=not args['--tokenized'],
-            score=score,
-            normal_form=lemmatize,
-            tag=tag,
-            newlines=True,  # not args['--inline'],
-            cache_size=args['--cache'],
-            thresh=float(args['--thresh']),
-        )
+    return show_dict_mem_usage(lang, path, verbose)
 
-    if args['dict']:
-        logger.addHandler(logging.StreamHandler())
-        logger.setLevel(logging.DEBUG if args['--verbose'] else logging.INFO)
-        logger.debug(args)
+@cli_dict.command(name='meta', context_settings={'show_default': True})
+@click.option('--lang', default='ru', help='Language to use. Allowed values: ru, uk')
+@click.option('--dict', 'path', help='Dictionary folder path')
+def cli_dict_meta(lang, path):
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.INFO)
+    logger.debug([lang, path])
 
-        if args['mem_usage']:
-            return show_dict_mem_usage(lang, path, args['--verbose'])
-        elif args['meta']:
-            return show_dict_meta(lang, path)
+    return show_dict_meta(lang, path)
 
 
 def _open_for_read(fn):
@@ -273,3 +286,6 @@ def _iter_tokens_tokenize(fp):
 def _iter_tokens_notokenize(fp):
     """ Return an iterator of input tokens; each line is a single token """
     return (line for line in (line.strip() for line in fp) if line)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ py_version = sys.version_info[:2]
 
 
 install_requires = [
-    'click',
     'dawg-python >= 0.7.1',
     'pymorphy3-dicts-ru'
 ]
@@ -36,7 +35,10 @@ if py_version < (3, 0):
     install_requires.append("backports.functools_lru_cache >= 1.0.1")
 
 
-extras_require = {'fast': []}
+extras_require = {
+    'CLI': ['click'],
+    'fast': []
+}
 if is_cpython:
     extras_require['fast'].append("DAWG >= 0.8")
     if py_version < (3, 5):

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ py_version = sys.version_info[:2]
 
 
 install_requires = [
+    'click',
     'dawg-python >= 0.7.1',
-    'docopt-ng >= 0.6',
     'pymorphy3-dicts-ru'
 ]
 if py_version < (3, 0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,49 +2,46 @@
 from __future__ import absolute_import
 import logging
 
+from click.testing import CliRunner
 import pytest
-import docopt
 
 from pymorphy3 import cli
 
 
-def run_pymorphy2(args=(), stdin=None):
-    cli.main(args)
+def run_pymorphy2(args=()):
+    runner = CliRunner(mix_stderr = False)
+    results = runner.invoke(cli.main, args)
 
+    return results.stdout, results.stderr
 
 def test_show_usage():
-    with pytest.raises(docopt.DocoptExit) as e:
-        run_pymorphy2([])
-    assert 'Usage:' in str(e.value)
+    out = ' '.join(run_pymorphy2([]))
+    assert 'Usage:' in out
 
 
-def test_show_memory_usage(capsys):
+def test_show_memory_usage():
     pytest.importorskip("psutil")
-
-    run_pymorphy2(['dict', 'mem_usage'])
-    out = ' '.join(capsys.readouterr())
+    out = ' '.join(run_pymorphy2(['dict', 'mem_usage']))
     assert 'Memory usage:' in out
 
 
-def test_show_dict_meta(capsys, morph):
+def test_show_dict_meta(morph):
     meta = morph.dictionary.meta
-    run_pymorphy2(['dict', 'meta'])
-    out = ' '.join(capsys.readouterr())
+    out = ' '.join(run_pymorphy2(['dict', 'meta']))
     assert meta['compiled_at'] in out
 
 
-def test_parse_basic(tmpdir, capsys):
+def test_parse_basic(tmpdir):
     logging.raiseExceptions = False
     try:
         p = tmpdir.join('words.txt')
-        p.write_text(u"""
+        p.write_text("""
         крот пришел
         """, encoding='utf8')
-        run_pymorphy2(["parse", str(p)])
-        out, err = capsys.readouterr()
+        out, err = run_pymorphy2(["parse", str(p)])
         print(out)
         print(err)
-        assert out.strip() == u"""
+        assert out.strip() == """
 крот{крот:1.000=NOUN,anim,masc sing,nomn}
 пришел{прийти:1.000=VERB,perf,intr masc,sing,past,indc}
         """.strip()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps=
+    click
     pytest
     pytest-cov
     tqdm


### PR DESCRIPTION
Following #16, instead of replacing the abandoned `docopt` with a forked version, this PR switch from `docopt` to `Click` which is in active development. Command line usages are unchanged, except some minor differences in the format of the generated help text.

I'll leave the decision to the maintainers of this fork as for whether it is worth it for future development.