### PR TITLE
build: enable dawg2 as `fast` deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     'fast': []
 }
 if is_cpython:
-    extras_require['fast'].append("DAWG >= 0.8")
+    extras_require['fast'].append("DAWG2 >= 0.8")
 
 
 setup(


### PR DESCRIPTION
This enables `pymorphy3[fast]` on Python >3.9 versions.

As of now, `pymorphy3[fast]` works only on <= 3.9 versions due to DAWG incompatibility with newer Python versions.
Someone made a fork of DAWG with support for modern Python - and called it [DAWG2](https://pypi.org/project/DAWG2/).