### PR TITLE
Simplify the use of psutil

### DIFF
--- a/pymorphy3/utils.py
+++ b/pymorphy3/utils.py
@@ -12,11 +12,7 @@ def get_mem_usage():
     """
     import psutil
     proc = psutil.Process(os.getpid())
-    try:
-        return proc.memory_info().rss
-    except AttributeError:
-        # psutil < 2.x
-        return proc.get_memory_info()[0]
+    return proc.memory_info().rss
 
 
 def combinations_of_all_lengths(it):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
     click
     pytest
     pytest-cov
-    psutil >= 2.0
+    psutil
     tqdm
 
     fast: lxml

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps=
     click
     pytest
     pytest-cov
+    psutil >= 2.0
     tqdm
 
     fast: lxml
@@ -22,7 +23,6 @@ commands=
 
     fast: pip install pymorphy3[fast]
 
-    pip install psutil
     pymorphy dict mem_usage
 
     py.test \


### PR DESCRIPTION
This PR simplifies the use of `psutil`.

Port of https://github.com/pymorphy2-fork/pymorphy2/pull/12.