### PR TITLE
Fix tests for command lines

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -7,7 +8,10 @@ from pymorphy3 import cli
 
 
 def run_pymorphy3(args=()):
-    runner = CliRunner(mix_stderr = False)
+    if sys.version_info >= (3, 10):
+        runner = CliRunner()
+    else:
+        runner = CliRunner(mix_stderr = False)
     results = runner.invoke(cli.main, args)
 
     return results.stdout, results.stderr


### PR DESCRIPTION
This PR fixes the tests for command lines.

The `mix_stderr` parameter in `CliRunner` was [removed](https://github.com/pallets/click/pull/2523) in `Click` 8.2.0 which also dropped support for Python <= 3.9.